### PR TITLE
Remove xys

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: xivo-sysconfd
 Section: python
 Priority: extra
-Maintainer: Wazo Maintainers <dev.wazo@gmail.com>
+Maintainer: Wazo Maintainers <dev@wazo.community>
 Build-Depends: debhelper (>= 9), dh-python, dh-systemd (>= 1.5), python-all (>= 2.7), python-setuptools
 Standards-Version: 3.9.6
 X-Python-Version: >= 2.7
@@ -15,6 +15,7 @@ Depends: ${python:Depends},
          xivo-lib-python,
          python-dumbnet,
          python-kombu (>= 4.2.1-3),
+         python-marshmallow,
          python-netifaces,
          python-vine,
          sudo

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,6 @@ Depends: ${python:Depends},
          xivo-lib-python,
          python-dumbnet,
          python-kombu (>= 4.2.1-3),
-         python-marshmallow,
          python-netifaces,
          python-vine,
          sudo

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
 kombu==4.2.1
 pyyaml==3.13
 requests==2.21.0
+marshmallow==3.0.0b14

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
 kombu==4.2.1
 pyyaml==3.13
 requests==2.21.0
-marshmallow==3.0.0b14

--- a/xivo_sysconf/modules/resolvconf.py
+++ b/xivo_sysconf/modules/resolvconf.py
@@ -135,6 +135,11 @@ search?:        !~~seqlen(1,6) [ !~search_domain example.com ]
 """)
 
 
+def _validate_resolv_conf(args):
+    if not xys.validate(args, RESOLVCONF_SCHEMA):
+        raise HttpReqError(415, "invalid arguments for command")
+
+
 def _resolv_conf_variables(args):
     xvars = {}
     xvars['_XIVO_NAMESERVER_LIST'] = \
@@ -182,8 +187,7 @@ def ResolvConf(args, options):
                 "maximum length exceeded for option search: %r" % list(args['search']),
             )
 
-    if not xys.validate(args, RESOLVCONF_SCHEMA):
-        raise HttpReqError(415, "invalid arguments for command")
+    _validate_resolv_conf(args)
 
     if not os.access(Rcc['resolvconf_path'], (os.X_OK | os.W_OK)):
         raise HttpReqError(

--- a/xivo_sysconf/modules/resolvconf.py
+++ b/xivo_sysconf/modules/resolvconf.py
@@ -71,6 +71,11 @@ domain:     !~search_domain
 """)
 
 
+def _validate_hosts(args):
+    if not xys.validate(args, HOSTS_SCHEMA):
+        raise HttpReqError(415, "invalid arguments for command")
+
+
 def Hosts(args, options):
     """
     POST /hosts
@@ -78,9 +83,7 @@ def Hosts(args, options):
     >>> hosts({'hostname':  'xivo',
                'domain':    'localdomain'})
     """
-
-    if not xys.validate(args, HOSTS_SCHEMA):
-        raise HttpReqError(415, "invalid arguments for command")
+    _validate_hosts(args)
 
     if not os.access(Rcc['hostname_path'], (os.X_OK | os.W_OK)):
         raise HttpReqError(

--- a/xivo_sysconf/modules/resolvconf.py
+++ b/xivo_sysconf/modules/resolvconf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2010-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -23,13 +23,15 @@ log = logging.getLogger('xivo_sysconf.modules.resolvconf')
 
 RESOLVCONFLOCK = RWLock()
 
-Rcc = {'hostname_file': os.path.join(os.path.sep, 'etc', 'hostname'),
-       'hostname_tpl_file': os.path.join('resolvconf', 'hostname'),
-       'hosts_file': os.path.join(os.path.sep, 'etc', 'hosts'),
-       'hosts_tpl_file': os.path.join('resolvconf', 'hosts'),
-       'resolvconf_file': os.path.join(os.path.sep, 'etc', 'resolv.conf'),
-       'resolvconf_tpl_file': os.path.join('resolvconf', 'resolv.conf'),
-       'lock_timeout': 60}
+Rcc = {
+    'hostname_file': os.path.join(os.path.sep, 'etc', 'hostname'),
+    'hostname_tpl_file': os.path.join('resolvconf', 'hostname'),
+    'hosts_file': os.path.join(os.path.sep, 'etc', 'hosts'),
+    'hosts_tpl_file': os.path.join('resolvconf', 'hosts'),
+    'resolvconf_file': os.path.join(os.path.sep, 'etc', 'resolv.conf'),
+    'resolvconf_tpl_file': os.path.join('resolvconf', 'resolv.conf'),
+    'lock_timeout': 60,
+}
 
 
 def _write_config_file(optname, xvars):
@@ -51,10 +53,12 @@ def _write_config_file(optname, xvars):
     template_lines = template_file.readlines()
     template_file.close()
 
-    txt = txtsubst(template_lines,
-                   xvars,
-                   Rcc["%s_file" % optname],
-                   'utf8')
+    txt = txtsubst(
+        template_lines,
+        xvars,
+        Rcc["%s_file" % optname],
+        'utf8',
+    )
 
     system.file_writelines_flush_sync(Rcc["%s_file" % optname], txt)
 
@@ -79,25 +83,35 @@ def Hosts(args, options):
         raise HttpReqError(415, "invalid arguments for command")
 
     if not os.access(Rcc['hostname_path'], (os.X_OK | os.W_OK)):
-        raise HttpReqError(415, "path not found or not writable or not executable: %r" % Rcc['hostname_path'])
+        raise HttpReqError(
+            415,
+            "path not found or not writable or not executable: %r" % Rcc['hostname_path'],
+        )
 
     if not os.access(Rcc['hosts_path'], (os.X_OK | os.W_OK)):
-        raise HttpReqError(415, "path not found or not writable or not executable: %r" % Rcc['hosts_path'])
+        raise HttpReqError(
+            415,
+            "path not found or not writable or not executable: %r" % Rcc['hosts_path'],
+        )
 
     if not RESOLVCONFLOCK.acquire_read(Rcc['lock_timeout']):
-        raise HttpReqError(503, "unable to take RESOLVCONFLOCK for reading after %s seconds" % Rcc['lock_timeout'])
+        raise HttpReqError(
+            503,
+            "unable to take RESOLVCONFLOCK for reading after %s seconds" % Rcc['lock_timeout'],
+        )
 
     hostnamebakfile = None
     hostsbakfile = None
 
     try:
         try:
-            hostnamebakfile = _write_config_file('hostname',
-                                                 {'_XIVO_HOSTNAME': args['hostname']})
+            hostnamebakfile = _write_config_file(
+                'hostname', {'_XIVO_HOSTNAME': args['hostname']},
+            )
 
-            hostsbakfile = _write_config_file('hosts',
-                                              {'_XIVO_HOSTNAME': args['hostname'],
-                                               '_XIVO_DOMAIN': args['domain']})
+            hostsbakfile = _write_config_file(
+                'hosts', {'_XIVO_HOSTNAME': args['hostname'], '_XIVO_DOMAIN': args['domain']},
+            )
 
             subprocess.call(['hostname', '-F', Rcc['hostname_file']])
 
@@ -160,23 +174,31 @@ def ResolvConf(args, options):
             raise HttpReqError(415, "duplicated search in %r" % list(args['search']))
 
         if len(''.join(args['search'])) > 255:
-            raise HttpReqError(415, "maximum length exceeded for option search: %r" % list(args['search']))
+            raise HttpReqError(
+                415,
+                "maximum length exceeded for option search: %r" % list(args['search']),
+            )
 
     if not xys.validate(args, RESOLVCONF_SCHEMA):
         raise HttpReqError(415, "invalid arguments for command")
 
     if not os.access(Rcc['resolvconf_path'], (os.X_OK | os.W_OK)):
-        raise HttpReqError(415, "path not found or not writable or not executable: %r" % Rcc['resolvconf_path'])
+        raise HttpReqError(
+            415,
+            "path not found or not writable or not executable: %r" % Rcc['resolvconf_path'],
+        )
 
     if not RESOLVCONFLOCK.acquire_read(Rcc['lock_timeout']):
-        raise HttpReqError(503, "unable to take RESOLVCONFLOCK for reading after %s seconds" % Rcc['lock_timeout'])
+        raise HttpReqError(
+            503,
+            "unable to take RESOLVCONFLOCK for reading after %s seconds" % Rcc['lock_timeout'],
+        )
 
     resolvconfbakfile = None
 
     try:
         try:
-            resolvconfbakfile = _write_config_file('resolvconf',
-                                                   _resolv_conf_variables(args))
+            resolvconfbakfile = _write_config_file('resolvconf', _resolv_conf_variables(args))
             return True
         except Exception, e:
             if resolvconfbakfile:
@@ -204,17 +226,19 @@ def safe_init(options):
     Rcc['lock_timeout'] = float(Rcc['lock_timeout'])
 
     for optname in ('hostname', 'hosts', 'resolvconf'):
-        Rcc["%s_tpl_file" % optname] = os.path.join(tpl_path,
-                                                    Rcc["%s_tpl_file" % optname])
+        Rcc["%s_tpl_file" % optname] = os.path.join(tpl_path, Rcc["%s_tpl_file" % optname])
 
-        Rcc["%s_custom_tpl_file" % optname] = os.path.join(custom_tpl_path,
-                                                           Rcc["%s_tpl_file" % optname])
+        Rcc["%s_custom_tpl_file" % optname] = os.path.join(
+            custom_tpl_path, Rcc["%s_tpl_file" % optname],
+        )
 
         Rcc["%s_path" % optname] = os.path.dirname(Rcc["%s_file" % optname])
-        Rcc["%s_backup_file" % optname] = os.path.join(backup_path,
-                                                       Rcc["%s_file" % optname].lstrip(os.path.sep))
-        Rcc["%s_backup_path" % optname] = os.path.join(backup_path,
-                                                       Rcc["%s_path" % optname].lstrip(os.path.sep))
+        Rcc["%s_backup_file" % optname] = os.path.join(
+            backup_path, Rcc["%s_file" % optname].lstrip(os.path.sep),
+        )
+        Rcc["%s_backup_path" % optname] = os.path.join(
+            backup_path, Rcc["%s_path" % optname].lstrip(os.path.sep),
+        )
 
 
 http_json_server.register(Hosts, CMD_RW, safe_init=safe_init, name='hosts')

--- a/xivo_sysconf/modules/tests/test_resolvconf.py
+++ b/xivo_sysconf/modules/tests/test_resolvconf.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import unittest
+
+from hamcrest import (
+    assert_that,
+    calling,
+    not_,
+    raises,
+)
+
+from ..resolvconf import (
+    HttpReqError,
+    _validate_hosts as validate_hosts,
+)
+
+
+class TestValidateHosts(unittest.TestCase):
+
+    def test_domain(self):
+        invalid_names = [
+            64 * 'a.wazo-platform.org',
+            '-NOT',
+            'NOT-',
+            'foo!bar',
+            'foo.-NOT.bar',
+        ]
+
+        for name in invalid_names:
+            body = {'domain': name, 'hostname': 'valid'}
+
+            assert_that(
+                calling(validate_hosts).with_args(body),
+                raises(HttpReqError),
+                name,
+            )
+
+        body = {'domain': 'a' * 63 + '.wazo-platform.org', 'hostname': 'valid'}
+
+        assert_that(
+            calling(validate_hosts).with_args(body),
+            not_(raises(HttpReqError)),
+        )
+
+    def test_hostname(self):
+        invalid_names = [
+            64 * 'a',
+            '-NOT',
+            'NOT-',
+            'foo!bar',
+        ]
+
+        for name in invalid_names:
+            body = {'domain': 'valid', 'hostname': name}
+
+            assert_that(
+                calling(validate_hosts).with_args(body),
+                raises(HttpReqError),
+                name,
+            )
+
+        body = {'domain': 'valid', 'hostname': 'foo-bar'}
+
+        assert_that(
+            calling(validate_hosts).with_args(body),
+            not_(raises(HttpReqError)),
+        )

--- a/xivo_sysconf/modules/tests/test_resolvconf.py
+++ b/xivo_sysconf/modules/tests/test_resolvconf.py
@@ -14,6 +14,7 @@ from hamcrest import (
 from ..resolvconf import (
     HttpReqError,
     _validate_hosts as validate_hosts,
+    _validate_resolv_conf as validate_resolv_conf,
 )
 
 
@@ -67,3 +68,83 @@ class TestValidateHosts(unittest.TestCase):
             calling(validate_hosts).with_args(body),
             not_(raises(HttpReqError)),
         )
+
+
+class TestValidateResolvConf(unittest.TestCase):
+
+    def test_nameservers(self):
+        assert_that(
+            calling(validate_resolv_conf).with_args({}),
+            raises(HttpReqError),
+        )
+
+        assert_that(
+            calling(validate_resolv_conf).with_args({'nameservers': []}),
+            raises(HttpReqError),
+        )
+
+        assert_that(
+            calling(validate_resolv_conf).with_args(
+                {'nameservers': ['10.0.0.1', '10.0.0.2', '10.0.0.3', '10.0.0.4']},
+            ),
+            raises(HttpReqError),
+        )
+
+        invalid_ip_or_domain = [
+            '-foo.wazo-platform.org',
+            None,
+            'a' * 64,
+            '127.0.0.-1',
+        ]
+
+        for ip_or_domain in invalid_ip_or_domain:
+            assert_that(
+                calling(validate_resolv_conf).with_args(
+                    {'nameservers': [ip_or_domain]},
+                ),
+                raises(HttpReqError),
+                ip_or_domain,
+            )
+
+    def test_search(self):
+        assert_that(
+            calling(validate_resolv_conf).with_args({'nameservers': ['valid'], 'search': []}),
+            raises(HttpReqError),
+        )
+
+        assert_that(
+            calling(validate_resolv_conf).with_args(
+                {
+                    'nameservers': ['valid'],
+                    'search': [
+                        'toto.1.tld',
+                        'toto.2.tld',
+                        'toto.3.tld',
+                        'toto.4.tld',
+                        'toto.5.tld',
+                        'toto.6.tld',
+                        'toto.7.tld',
+                    ],
+                },
+            ),
+            raises(HttpReqError),
+        )
+
+        invalid_names = [
+            64 * 'a' + '.wazo-platform.org',
+            '-NOT',
+            'NOT-',
+            'foo!bar',
+            'foo.-NOT.bar',
+        ]
+
+        for name in invalid_names:
+            body = {
+                'nameservers': ['valid'],
+                'search': [name],
+            }
+            assert_that(
+                calling(validate_resolv_conf).with_args(body),
+                raises(HttpReqError),
+                name,
+            )


### PR DESCRIPTION
This branch copies the only used validators from lib-python to sysconfd to be able to remove the validation framework from lib-python.