### PR TITLE
remove usage of PID file and use systemd options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN python setup.py install
 RUN touch /etc/network/interfaces
 RUN touch /var/log/xivo-sysconfd.log
 RUN mkdir /etc/xivo/
-RUN mkdir /run/xivo-sysconfd
 RUN cp -a etc/xivo/* /etc/xivo/
 WORKDIR /root
 

--- a/debian/xivo-sysconfd.service
+++ b/debian/xivo-sysconfd.service
@@ -1,11 +1,13 @@
 [Unit]
 Description=xivo-sysconfd server
 After=network.target rabbitmq-server.service
-Before=monit.service
+StartLimitBurst=15
+StartLimitIntervalSec=150
 
 [Service]
 ExecStart=/usr/bin/xivo-sysconfd
-PIDFile=/run/xivo-sysconfd.pid
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
reason: systemd restart remove monit usage based on pid file