### PR TITLE
revert kombu version to 4.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/wazo-platform/xivo-bus/archive/master.zip
 https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
-kombu==4.6.11
+kombu==4.2.1
 pyyaml==3.13
 requests==2.21.0


### PR DESCRIPTION
reason: too much effort to package all deps in python2